### PR TITLE
Build docker image and publish to GitHub Container Registry

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+Dockerfile

--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -1,0 +1,49 @@
+#
+name: Create and publish a Docker image
+
+# Configures this workflow to run every time a change is pushed to the branch called `release`.
+on:
+  push:
+    branches: ['samsung_wasm']
+
+# Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+# There is a single job in this workflow. It's configured to run on the latest available version of Ubuntu.
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
+    permissions:
+      contents: read
+      packages: write
+      # 
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
+      # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
+      # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
+      - name: Build and push Docker image
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ An easy method for building Moonlight for Samsung TV
 - This Dockerfile and support files have been adapted from [jellyfin-docker-tizen](https://github.com/babagreensheep/jellyfin-tizen-docker)
 - Dockerfile readapted for my repository tizen from [pablojrl123](https://github.com/pablojrl123/moonlight-tizen-docker)
 
-## Building
+## Using the prebuilt Docker image
 1. Enable developer mode on the TV (more information on [official Samsung guide](https://developer.samsung.com/smarttv/develop/getting-started/using-sdk/tv-device.html)):
 	- Go to Apps.
 	- Press `12345` on the remote; a dialog should pop up.
@@ -15,11 +15,43 @@ An easy method for building Moonlight for Samsung TV
 	- Power off and power on the TV as instructed; go once again to Apps.
 	- Depending on your model, a "DEVELOP MODE" or similar message might appear.
    
+2. Deploy the application to the TV:
+	- Run and enter a container; the container will be removed automatically on exit:
+	 ```
+	 docker run -it --rm ghcr.io/kyrofrcode/moonlight-chrome-tizen:samsung_wasm
+	 ```
+	- Connect to your TV over Smart Development Bridge:
+	 ```sh
+	 sdb connect YOUR_TV_IP
+	 ```
+	- Confirm that you are connected, take note of the device ID:
+	 ```
+	 sdb devices
+	 ```
+	 The device ID will be the last column, something like `UE65NU7400`.
+	- Install the package:
+	 ```sh
+	 tizen install -n MoonlightWasm.wgt -t DEVICE_ID
+	 ```
+	 Moonlight should now appear in your Recent Apps - or similar page - on your TV.
+	- Exit the container:
+	 ```sh
+	 exit
+	 ```
+	- (Optional) Remove the Docker image:
+	 ```sh
+	 docker image rm ghcr.io/kyrofrcode/moonlight-chrome-tizen:samsung_wasm
+	 ```
+
+## Building the Docker image from source
+1. Enable developer mode on the TV using the steps from the previous section
+
 2. Build the application within a Docker image:
 	```
 	docker build -t moonlight-tizen .
 	```
 	This will take a while.
+
 3. Deploy the application to the TV:
 	- Run and enter a container; the container will be removed automatically on exit:
 	 ```


### PR DESCRIPTION
The docker image takes a really long time to build, and it's the same process for everyone. Instead of making everyone download the repository and build the docker image, we can use GitHub Actions to build the image whenever the repo is updated. This will create a new docker image hosted on GitHub, which is free for public repositories.

I also updated the Dockerfile to use a multistage build to delete some unnecessary installation and build files, making it quicker to download. This brings the final image from ~3GB to ~1GB.

Tested it by pulling the package at ghcr.io/pkmnnerd/moonlight-chrome-tizen:samsung_wasm and running it on my device. I was able to install Moonlight successfully.
